### PR TITLE
Add Organization and Payroll Period Controllers and Models

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,7 +1,14 @@
+# frozen_string_literal: true
+
+# OrganizationsController handles requests for organizations.
 class OrganizationsController < ApplicationController
   def index
+    @organizations = Organization.all
   end
 
   def show
+    @organization = Organization.find(params[:id])
+    @payroll_periods = @organization.payroll_periods.order(start_date: :desc)
+    @current_period = @organization.current_payroll_period
   end
 end

--- a/app/controllers/payroll_periods_controller.rb
+++ b/app/controllers/payroll_periods_controller.rb
@@ -1,13 +1,48 @@
+# frozen_string_literal: true
+
+# PayrollPeriodsController handles requests for payroll periods.
 class PayrollPeriodsController < ApplicationController
+  before_action :set_organization
+  before_action :set_payroll_period, only: %i[update destroy]
+
   def index
+    @payroll_periods = @organization.payroll_periods.order(start_date: :desc)
   end
 
   def create
+    @payroll_period = @organization.payroll_periods.new(payroll_period_params)
+
+    if @payroll_period.save
+      redirect_to @organization, notice: 'Payroll period was successfully created.'
+    else
+      render :new
+    end
   end
 
   def update
+    if @payroll_period.update(payroll_period_params)
+      redirect_to @organization, notice: 'Payroll period was successfully updated.'
+    else
+      render :edit
+    end
   end
 
   def destroy
+    @payroll_period.destroy
+    redirect_to @organization, notice: 'Payroll period was successfully destroyed.'
+  end
+
+  private
+
+  def set_organization
+    @organization = Organization.find(params[:organization_id])
+  end
+
+  def set_payroll_period
+    @payroll_period = @organization.payroll_periods.find(params[:id])
+  end
+
+  def payroll_period_params
+    params.require(:payroll_period).permit(:start_date, :end_date, :period_type)
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,2 +1,11 @@
+# frozen_string_literal: true
+
+# Organization represents a company or organization.
 class Organization < ApplicationRecord
+  has_many :payroll_periods
+
+  # Returns the current payroll period for this organization.
+  def current_payroll_period
+    payroll_periods.where('start_date <= ? AND end_date >= ?', Date.current, Date.current).first
+  end
 end

--- a/app/models/payroll_period.rb
+++ b/app/models/payroll_period.rb
@@ -1,3 +1,35 @@
+# frozen_string_literal: true
+
+# PayrollPeriod represents a period of time for which payroll is calculated.
 class PayrollPeriod < ApplicationRecord
   belongs_to :organization
+
+  validates :start_date, :end_date, presence: true
+  validates :period_type, inclusion: { in: %w[weekly biweekly monthly custom] }
+  validate :end_date_after_start_date
+  validate :no_overlap_with_existing_periods
+
+  private
+
+  # Validates that end_date is after start_date.
+  def end_date_after_start_date
+    return if end_date.blank? || start_date.blank?
+
+    return unless end_date < start_date
+
+    errors.add(:end_date, 'must be after the start date')
+  end
+
+  # Validates that the payroll period does not overlap with existing periods.
+  def no_overlap_with_existing_periods
+    overlapping_periods = organization.payroll_periods
+                                      .where.not(id:)
+                                      .where('(start_date <= ? AND end_date >= ?) OR (start_date <= ? AND end_date >= ?)
+                                             OR (start_date >= ? AND end_date <= ?)',
+                                             start_date, start_date, end_date, end_date, start_date, end_date)
+
+    return unless overlapping_periods.exists?
+
+    errors.add(:base, 'Payroll period overlaps with existing periods')
+  end
 end


### PR DESCRIPTION
This PR adds the necessary controllers and models to handle requests for organizations and payroll periods. The OrganizationsController handles requests for organizations, while the `PayrollPeriodsController` handles requests for payroll periods. The `Organization` and `PayrollPeriod` models have been updated to include the necessary associations and validations.

This PR includes the following changes:

- Added `OrganizationsController` and `PayrollPeriodsController` to handle requests for organizations and payroll periods
- Updated `Organization` and `PayrollPeriod` models to include necessary associations and validations
- Added `current_payroll_period` method to `Organization` model
- Added `end_date_after_start_date` and `no_overlap_with_existing_periods` validations to `PayrollPeriod` model